### PR TITLE
[Fix] 공구와 공구에 입찰한 입찰정보 조회 api 등록된 입찰 없어도 조회 가능하도록 수정

### DIFF
--- a/project/src/main/java/org/example/fourtreesproject/groupbuy/controller/GroupBuyController.java
+++ b/project/src/main/java/org/example/fourtreesproject/groupbuy/controller/GroupBuyController.java
@@ -63,9 +63,9 @@ public class GroupBuyController {
             Long gpbuyIdx
     ) {
         RegisteredGroupBuyResponse result = gpbuyService.findBidList(gpbuyIdx);
-        if (result.getBidList().size() == 0) {
-            throw new InvalidGroupBuyException(BaseResponseStatus.GROUPBUY_LIST_REGISTERD_BID_EMPTY);
-        }
+//        if (result.getBidList().size() == 0) {
+//            throw new InvalidGroupBuyException(BaseResponseStatus.GROUPBUY_LIST_REGISTERD_BID_EMPTY);
+//        }
         if (gpbuyIdx == null) {
             throw new InvalidGroupBuyException(REQUEST_FAIL_INVALID);
         }


### PR DESCRIPTION
공구 상세(대기) 페이지에서 공구 입찰 목록이 없을 때 예외 처리 되는 부분 주석